### PR TITLE
add lint rule command

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.7.3",
     "@cloudflare/workers-types": "^4.20240502.0",
+    "@types/lodash.kebabcase": "^4.1.9",
     "tsx": "^4.9.3",
     "typescript": "^5.4.5",
     "wrangler": "^3.53.1"
@@ -27,7 +28,8 @@
     "@discordjs/rest": "^2.3.0",
     "dedent": "^1.5.3",
     "discord-api-types": "^0.37.83",
-    "discord-verify": "^1.2.0"
+    "discord-verify": "^1.2.0",
+    "lodash.kebabcase": "^4.1.1"
   },
   "engines": {
     "node": "^20.11.0 || >=21.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ dependencies:
   discord-verify:
     specifier: ^1.2.0
     version: 1.2.0
+  lodash.kebabcase:
+    specifier: ^4.1.1
+    version: 4.1.1
 
 devDependencies:
   '@biomejs/biome':
@@ -28,6 +31,9 @@ devDependencies:
   '@cloudflare/workers-types':
     specifier: ^4.20240502.0
     version: 4.20240502.0
+  '@types/lodash.kebabcase':
+    specifier: ^4.1.9
+    version: 4.1.9
   tsx:
     specifier: ^4.9.3
     version: 4.9.3
@@ -733,6 +739,16 @@ packages:
     resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
     dev: false
 
+  /@types/lodash.kebabcase@4.1.9:
+    resolution: {integrity: sha512-kPrrmcVOhSsjAVRovN0lRfrbuidfg0wYsrQa5IYuoQO1fpHHGSme66oyiYA/5eQPVl8Z95OA3HG0+d2SvYC85w==}
+    dependencies:
+      '@types/lodash': 4.17.4
+    dev: true
+
+  /@types/lodash@4.17.4:
+    resolution: {integrity: sha512-wYCP26ZLxaT3R39kiN2+HcJ4kTd3U1waI/cY7ivWYqFP6pW3ZNpvi6Wd6PHZx7T/t8z0vlkXMg3QYLa7DZ/IJQ==}
+    dev: true
+
   /@types/mime@1.3.5:
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
     dev: false
@@ -1040,6 +1056,10 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
     dev: true
+
+  /lodash.kebabcase@4.1.1:
+    resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
+    dev: false
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}

--- a/src/commands/lint-rule.ts
+++ b/src/commands/lint-rule.ts
@@ -1,0 +1,99 @@
+import { SlashCommandBuilder } from '@discordjs/builders';
+import dedent from 'dedent';
+import {
+  type APIApplicationCommandAutocompleteInteraction,
+  type APIChatInputApplicationCommandInteraction,
+  ApplicationCommandOptionType,
+  InteractionResponseType,
+} from 'discord-api-types/v10';
+import kebabCase from 'lodash.kebabcase';
+import { reply } from '../reply.js';
+
+interface Rule {
+  name: string;
+  version: string;
+  recommended: boolean;
+  deprecated: boolean;
+  fixKind?: 'safe' | 'unsafe';
+  docs: string;
+}
+
+interface RulesMetadata {
+  lints: {
+    languages: {
+      [language: string]: {
+        [category: string]: Record<string, Rule>;
+      };
+    };
+  };
+}
+
+export async function onLintRuleSlashCommand(interaction: APIChatInputApplicationCommandInteraction) {
+  if (!interaction.data.options || interaction.data.options[0].type !== ApplicationCommandOptionType.String) {
+    return new Response();
+  }
+
+  const rule = interaction.data.options[0].value;
+
+  const { lints } = (await fetch('https://biomejs.dev/metadata/rules.json').then((res) => res.json())) as RulesMetadata;
+  const ruleData = Object.values(lints.languages)
+    .flatMap((language) => Object.values(language))
+    .flatMap((category) => Object.values(category))
+    .find((r) => r.name.toLowerCase() === rule.toLowerCase());
+
+  if (!ruleData) {
+    return reply(InteractionResponseType.ChannelMessageWithSource, {
+      content: `Rule \`${rule}\` not found`,
+      flags: 64,
+    });
+  }
+
+  return reply(InteractionResponseType.ChannelMessageWithSource, {
+    content: dedent`
+      ## ${ruleData.name} (since \`v${ruleData.version}\`)
+      ${ruleData.recommended ? '🌟 Recommended' : ''}${ruleData.deprecated ? '⚠️ Deprecated' : ''}
+      ${ruleData.fixKind ? `\nFix kind: ${ruleData.fixKind}\n` : ''}
+      -${ruleData.docs.split('\n\n')[0]}
+
+      Docs: <https://biomejs.dev/linter/rules/${kebabCase(ruleData.name)}>
+    `,
+  });
+}
+
+export async function onLintRuleAutocomplete(interaction: APIApplicationCommandAutocompleteInteraction) {
+  if (!interaction.data.options || interaction.data.options[0].type !== ApplicationCommandOptionType.String) {
+    return new Response();
+  }
+
+  const rule = interaction.data.options[0].value;
+
+  const { lints } = (await fetch('https://biomejs.dev/metadata/rules.json').then((res) => res.json())) as RulesMetadata;
+  const rules = Object.values(lints.languages)
+    .flatMap((language) => Object.values(language))
+    .flatMap((category) => Object.values(category))
+    .filter((r) => r.name.toLowerCase().includes(rule.toLowerCase()))
+    .sort((a, b) => {
+      if (a.name < b.name) {
+        return -1;
+      }
+      if (a.name > b.name) {
+        return 1;
+      }
+      return 0;
+    })
+    .slice(0, 25);
+
+  return reply(InteractionResponseType.ApplicationCommandAutocompleteResult, {
+    choices: rules.map((r) => ({
+      name: r.name,
+      value: r.name,
+    })),
+  });
+}
+
+export const slashCommandData = new SlashCommandBuilder()
+  .setName('lint-rule')
+  .setDescription('Get info from a specific lint rule')
+  .addStringOption((option) =>
+    option.setName('rule').setDescription('The name of the lint rule').setAutocomplete(true).setRequired(true),
+  );

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,13 @@
 import { type APIInteraction, InteractionResponseType } from 'discord-api-types/v10';
 import { PlatformAlgorithm, isValidRequest } from 'discord-verify';
 import { onPluginsSlashCommand } from './commands/arewepluginsyet.js';
+import { onLintRuleAutocomplete, onLintRuleSlashCommand } from './commands/lint-rule.js';
 import { onSupportedLanguagesSlashCommand } from './commands/supported-languages.js';
 import { onTestSlashCommand } from './commands/test.js';
 import { handleGitHubWebhook } from './gh-webhook/github.js';
 import { reply } from './reply.js';
-import { isChatInputCommand, isMessageComponent, isPing } from './typeguards.js';
+import { isAutocomplete, isChatInputCommand, isMessageComponent, isPing } from './typeguards.js';
+
 export type Env = {
   PUBLIC_KEY: string;
   DISCORD_WEBHOOK: string;
@@ -46,10 +48,19 @@ async function handleInteraction(request: Request, env: Env): Promise<Response> 
     switch (interaction.data.name) {
       case 'arewepluginsyet':
         return onPluginsSlashCommand(interaction);
+      case 'lint-rule':
+        return onLintRuleSlashCommand(interaction);
       case 'supported-languages':
         return onSupportedLanguagesSlashCommand(interaction);
       case 'test':
         return onTestSlashCommand(interaction);
+    }
+  }
+
+  if (isAutocomplete(interaction)) {
+    switch (interaction.data.name) {
+      case 'lint-rule':
+        return onLintRuleAutocomplete(interaction);
     }
   }
 

--- a/src/reply.ts
+++ b/src/reply.ts
@@ -1,4 +1,8 @@
-import type { APIInteractionResponseCallbackData, InteractionResponseType } from 'discord-api-types/v10';
+import type {
+  APICommandAutocompleteInteractionResponseCallbackData,
+  APIInteractionResponseCallbackData,
+  InteractionResponseType,
+} from 'discord-api-types/v10';
 
 function respond(value: unknown) {
   const json = JSON.stringify(value);
@@ -9,6 +13,9 @@ function respond(value: unknown) {
   });
 }
 
-export function reply(type: InteractionResponseType, data?: APIInteractionResponseCallbackData) {
+export function reply(
+  type: InteractionResponseType,
+  data?: APIInteractionResponseCallbackData | APICommandAutocompleteInteractionResponseCallbackData,
+) {
   return respond({ type, data });
 }

--- a/src/typeguards.ts
+++ b/src/typeguards.ts
@@ -1,4 +1,5 @@
 import {
+  type APIApplicationCommandAutocompleteInteraction,
   type APIApplicationCommandInteraction,
   type APIChatInputApplicationCommandInteraction,
   type APIInteraction,
@@ -10,6 +11,12 @@ import {
 
 export function isApplicationCommand(interaction: APIInteraction): interaction is APIApplicationCommandInteraction {
   return interaction.type === InteractionType.ApplicationCommand;
+}
+
+export function isAutocomplete(
+  interaction: APIInteraction,
+): interaction is APIApplicationCommandAutocompleteInteraction {
+  return interaction.type === InteractionType.ApplicationCommandAutocomplete;
 }
 
 export function isChatInputCommand(


### PR DESCRIPTION
Adds a command to dynamically look up any lint rule. The implementation is probably slower than it should be as it fetches the metadata from all rules which is like >256 kb of json. Any optimizations are welcome
![image](https://github.com/biomejs/discord-utils-bot/assets/53496941/e45dde90-32b0-481f-8f88-1c3ee69e50ff)

Also has dynamic autocomplete:
![image](https://github.com/biomejs/discord-utils-bot/assets/53496941/e474fcee-0fef-479f-9353-49ef3f6efe18)
